### PR TITLE
Thomas/move to npm org

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-	"name": "bridge-model-viewer",
-	"version": "0.7.7",
+	"name": "@bridge-editor/model-viewer",
+	"version": "0.8.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
-			"name": "bridge-model-viewer",
-			"version": "0.7.7",
+			"name": "@bridge-editor/model-viewer",
+			"version": "0.8.0",
 			"license": "MIT",
 			"dependencies": {
 				"molang": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "bridge-model-viewer",
-	"version": "0.7.7",
+	"version": "0.8.0",
 	"description": "A fast parser for Minecraft's Molang",
 	"directories": {
 		"lib": "lib"

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "bridge-model-viewer",
+	"name": "@bridge-editor/model-viewer",
 	"version": "0.8.0",
 	"description": "A fast parser for Minecraft's Molang",
 	"directories": {


### PR DESCRIPTION
So that we can continue to update this module it has been republished under the @bridge-editor NPM org.

- Renamed module from `bridge-model-viewer` to @bridge-editor/model-viewer`
- Bumped version to v0.8.0
- Released the changes from #4 by @rtm516 