### PR TITLE
Fix animations without end keyframe going wacky

### DIFF
--- a/lib/Animations/Animation.ts
+++ b/lib/Animations/Animation.ts
@@ -72,7 +72,7 @@ export class Animation {
 
 				if (time > this.currentTime) {
 					continue
-				} else if (time === this.currentTime) {
+				} else if (time === this.currentTime || i === timestamps.length - 1) {
 					if (Array.isArray(transform)) {
 						return transform.map((t) =>
 							typeof t === 'string' ? this.execute(t) : t


### PR DESCRIPTION
Animations using keyframes where the animation length is longer than the last keyframe will cause unexpected behaviour - notably, a continuation of the animation, whereas in-game, the animation simply halts at the last keyframe.

This PR fixes it by stopping on the last keyframe after reaching it, instead of trying to interpolate to the first keyframe.

## Without fix
Notice how each anvil continues growing, past its last keyframe. (The structure block is the only correctly-scaled block at the end, since its last keyframe is the same as the animation length.)

[animation bug.webm](https://github.com/user-attachments/assets/edc68ef9-f54d-4f0b-9568-499a24de7857)

## In-game animation
Notice how the animation stops after reaching the last keyframe.

[as_intended.webm](https://github.com/user-attachments/assets/2963c2c4-3254-4b25-888e-861d1e404fbb)

## Proof of the fix
[proof.webm](https://github.com/user-attachments/assets/2c39b4c8-d181-4e83-ae11-1c986c042c69)